### PR TITLE
[jsk_2013_04_pr2_610/package.xml & launch/planner.launch] fix: validate launch file

### DIFF
--- a/jsk_2013_04_pr2_610/launch/planner.launch
+++ b/jsk_2013_04_pr2_610/launch/planner.launch
@@ -12,6 +12,7 @@
     <arg name="description" value="$(find jsk_2013_04_pr2_610)/pddl/description.l"/>
     <arg name="planner" value="ffha" />
     <arg name="debug" value="$(arg debug)" />
+    <arg name="planner_option" value="" />
   </include>
 
   <include unless="$(arg use_ffha)"

--- a/jsk_2013_04_pr2_610/package.xml
+++ b/jsk_2013_04_pr2_610/package.xml
@@ -39,6 +39,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>jsk_smart_gui</run_depend>
   <run_depend>task_compiler</run_depend>
+  <run_depend>sound_play</run_depend>
+  <run_depend>pddl_planner_viewer</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
fixed roslaunch validation error:

```bash
🍢  rosrun roslaunch roslaunch-check planner.launch
checking planner.launch
Traceback (most recent call last):
  File "/opt/ros/hydro/share/roslaunch/scripts/roslaunch-check", line 85, in <module>
    error_msg = check_roslaunch_file(roslaunch_path)
  File "/opt/ros/hydro/share/roslaunch/scripts/roslaunch-check", line 45, in check_roslaunch_file
    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/rlutil.py", line 199, in check_roslaunch
    base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 316, in roslaunch_deps
    rl_file_deps(file_deps, launch_file, verbose)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 217, in rl_file_deps
    parse_launch(launch_file, file_deps, verbose)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 202, in parse_launch
    _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 137, in _parse_launch
    _parse_launch(tag.childNodes, launch_file, file_deps, verbose, context)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 172, in _parse_launch
    _parse_launch(launch_tag.childNodes, sub_launch_file, file_deps, verbose, sub_context)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 140, in _parse_launch
    v = _parse_arg(tag, context)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 108, in _parse_arg
    return (name, _get_arg_value(tag, context))
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/depends.py", line 95, in _get_arg_value
    raise RoslaunchDepsException("No value for arg [%s]"%(name))
roslaunch.depends.RoslaunchDepsException: No value for arg [planner_option]
```

=> added missing `planner_option` with value `""`(empty string) on `use_ffha:=true`. (but roslaunch itself works without fix...)

```bash
🍢  rosrun roslaunch roslaunch-check planner.launch
checking planner.launch
...writing test results to /home/leus/ros/hydro/build/jsk_pcl_ros/test_results/jsk_2013_04_pr2_610/rosunit-roslaunch_check_planner_launch.xml
FAILURE:
[planner.launch]:
	Missing manifest dependencies: jsk_2013_04_pr2_610/manifest.xml: sound_play, pddl_planner_viewer
wrote test file to [/home/leus/ros/hydro/build/jsk_pcl_ros/test_results/jsk_2013_04_pr2_610/rosunit-roslaunch_check_planner_launch.xml]
```

=> added `sound_play` and `pddl_planner_viewer`(is it released?) to `run_depend` (it also works on roslaunch without fix.)