### PR TITLE
[jsk_2021_10_semi] add spotkinova support

### DIFF
--- a/jsk_2021_10_semi/README.md
+++ b/jsk_2021_10_semi/README.md
@@ -4,18 +4,53 @@ https://github.com/k-okada/jsk_demos/tree/jsk_2021_10_semi/jsk_2021_10_semi
 
 ## ロボットモデルの作り方
 
+```bash
+sudo apt install python3 python3-pip
+python3 -m pip install --user conan
+conan config set general.revisions_enabled=1
+conan profile new default --detect > /dev/null
+conan profile update settings.compiler.libcxx=libstdc++11 default
 ```
+
+ターミナルを立ち上げ直す.
+
+```bash
 source /opt/ros/melodic/setup.bash
-mkdir -p semi_ws/src
-cd semi_ws/src
+mkdir -p ~/semi_spotkinova_ws/src
+cd ~/semi_spotkinova_ws/src
+wstool init
+wstool set jsk-ros-pkg/jsk_robot https://github.com/sktometometo/jsk_robot.git --git -v develop/spot -y
+wstool update
+wstool merge jsk-ros-pkg/jsk_robot/jsk_kinova_robot/jsk_kinova.rosinstall
+wstool merge jsk-ros-pkg/jsk_robot/jsk_spot_robot/jsk_spot_user.rosinstall
+wstool update
+rosdep update
+rosdep install -y -r --from-paths . --ignore-src
+pip3 install -r jsk-ros-pkg/jsk_robot/jsk_spot_robot/requirements.txt
+cd ~/semi_spotkinova_ws
+catkin init
+catkin build spotkinovaeus -vi
+```
+
+その後、ターミナルを再び立ち上げ直す.
+
+```bash
+source /opt/ros/melodic/setup.bash
+mkdir -p ~/semi_ws/src
+cd ~/semi_ws/src
 wstool init
 wstool merge https://raw.githubusercontent.com/k-okada/jsk_demos/jsk_2021_10_semi/jsk_2021_10_semi/semi.rosinstall
 wstool update
+rosdep update
 rosdep install --from-paths . --ignore-src -y -r
 cd ..
 git clone https://github.com/k-okada/jsk_demos -b jsk_2021_10_semi
 cd src
 ln -sf ../jsk_demos/jsk_2021_10_semi/ .
+ln -sf ~/semi_spotkinova_ws/src/jsk-ros-pkg/jsk_robot/jsk_spot_robot/spoteus
+rm -rf ./jsk_robot/jsk_kinova_robot/kinovaeus
+ln -sf ~/semi_spotkinova_ws/src/jsk-ros-pkg/jsk_robot/jsk_kinova_robot/kinovaeus ./jsk_robot/jsk_kinova_robot/kinovaeus
+ln -sf ~/semi_spotkinova_ws/src/jsk-ros-pkg/jsk_robot/jsk_spotkinova_robot/spotkinovaeus .
 cd ..
 catkin build -vi
 source devel/setup.bash
@@ -39,6 +74,10 @@ source devel/setup.bash
 (load "package://fetcheus/fetch.l")
 (setq *fetch* (fetch))
 (objects (list *fetch*))
+
+(load "package://spotkinovaeus/spotkinova.l")
+(setq *spotkinova* (spotkinova))
+(objects (list *spotkinova*))
 
 (load "package://pr2eus/pr2.l")
 (setq *pr2* (pr2))

--- a/jsk_2021_10_semi/euslisp/demo.l
+++ b/jsk_2021_10_semi/euslisp/demo.l
@@ -14,7 +14,11 @@
   (require "package://pr2eus/pr2.l")
   (setq *pr2* (pr2)))
 
-(objects (list *room73b2* *nao* *fetch* *pr2*))
+(when (not (boundp '*spotkinova*))
+  (require "package://spotkinovaeus/spotkinova.l")
+  (setq *spotkinova* (spotkinova)))
+
+(objects (list *room73b2* *nao* *fetch* *pr2* *spotkinova*))
 
 (defun wait-for-human ()
   (send *pr2* :move-to (make-coords :pos #f(5000 000 0) :rpy (float-vector pi 0 0)) :world)


### PR DESCRIPTION
spotkinovaをとりあえず出せるようにしました。依存関係のせいで、結局spotkinova用のワークスペースを作った上でspotkinovaeus, spoteus, kinovaeus だけをbuildしてもらう必要があります。
一度buildすればeusのモデルはできるので, semi_wsにシンボリックリンクを貼れば, eusモデルのロードはできました。
base_linkが胴体なので,デフォルトだと地面に埋まっていますが....
あとなんか色もついてないです。

![Screenshot from 2021-11-10 17-01-04](https://user-images.githubusercontent.com/9410362/141073416-0bd69488-3055-436e-ac8b-ee9fd3f914dc.png)

