### PR TITLE
[jsk_maps] Add publish_scene.l to start_map_eng2.launch to visualize eus model on rviz

### DIFF
--- a/jsk_maps/launch/start_map_eng2.launch
+++ b/jsk_maps/launch/start_map_eng2.launch
@@ -4,6 +4,7 @@
   <arg name="launch_map_server" default="true" />
   <arg name="use_machine" default="false" />
   <arg name="use_pictogram" default="false" />
+  <arg name="use_publish_scene" default="true" />
 
   <machine name="localhost" address="localhost" if="$(arg use_machine)" />
 
@@ -30,5 +31,12 @@
         output="screen" >
     <param name="~scene" value="eng2" />
     <param name="~use_pictogram" value="$(arg use_pictogram)" />
+  </node>
+
+  <!-- for visualizing eus models on rviz -->
+  <node if="$(arg use_publish_scene)"
+        name="publish_eng2_scene" pkg="roseus" type="roseus"
+        args="$(find jsk_maps)/tools/publish_scene.l"
+        output="screen" >
   </node>
 </launch>


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_demos/pull/1361
`publish_scene.l` starts as default in `start_map_eng2.launch`